### PR TITLE
New updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ A **Laravel 10 API-driven service** for managing translations across multiple lo
 -   OpenAPI documentation auto-generated with Scramble.
 -   PHPUnit & Pest testing of critical features.
 
+## Locale Management
+
+-   Locales are stored in the `locales` table with `code` (e.g., `en`, `fr`, `es`) and `name` fields.
+-   New locales can be added via the `/api/locales` POST route.
+-   Each translation references a `locale_id` for efficient lookups.
+-   This ensures the system can scale to new languages without schema changes.
+
 ---
 
 ## **Technical Highlights**
@@ -41,9 +48,8 @@ A **Laravel 10 API-driven service** for managing translations across multiple lo
     -   Explicit `belongsToMany` and `hasMany` relations for clarity and performance.
     -   Resource classes used selectively to balance readability and response speed.
 
--   **Authentication**
-    -   Token-based API authentication using Laravel Sanctum.
-    -   `login` and `logout` endpoints provided.
+-   **Authentication** - Token-based API authentication using Laravel Sanctum. - `login` and `logout` endpoints provided.
+    > **Test User Info:**<br>email: test_user@tms.com<br>password: 12345678
 
 ---
 
@@ -102,6 +108,7 @@ php artisan test
 | `/api/translations/{content}`              | PUT    | Update a translation set                                          | Yes  |
 | `/api/translations/export/{tag}/{locale?}` | GET    | Export translations in JSON format for frontend                   | Yes  |
 | `/api/locales`                             | GET    | List all locales                                                  | Yes  |
+| `/api/locales`                             | POST   | Create (add) a new locale                                         | Yes  |
 | `/api/tags`                                | GET    | List all tags                                                     | Yes  |
 | `/api/auth/login`                          | POST   | Login and receive API token                                       | No   |
 | `/api/auth/logout`                         | POST   | Revoke API token                                                  | Yes  |

--- a/app/Http/Controllers/LocalesController.php
+++ b/app/Http/Controllers/LocalesController.php
@@ -38,6 +38,12 @@ class LocalesController extends Controller
      * @bodyParam code string required Unique locale code. Example: en, fr, es
      * @bodyParam name string required Descriptive name for locale. Example: English
      *
+     * @response 201 {
+     *   "id": 3,
+     *   "code": "es",
+     *   "name": "Spanish"
+     * }
+     * 
      * @param \App\Http\Requests\SaveLocaleRequest $request
      * @return \Illuminate\Http\JsonResponse
      */

--- a/app/Http/Controllers/LocalesController.php
+++ b/app/Http/Controllers/LocalesController.php
@@ -2,14 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\SaveLocaleRequest;
 use App\Models\Locale;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 
 /**
  * @group Locales
  *
- * API for retrieving available locales.
+ * API for managing locales.
  */
 class LocalesController extends Controller
 {
@@ -20,16 +20,29 @@ class LocalesController extends Controller
      * Returns all supported locales ordered by name.  
      * Each locale contains its `id`, `code`, and `name`.
      * @authenticated
-     * @response 200 [
-     *   { "id": 1, "code": "en", "name": "English" },
-     *   { "id": 2, "code": "fr", "name": "French" },
-     *   { "id": 3, "code": "es", "name": "Spanish" }
-     * ]
+     * @response 200 []
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function __invoke():JsonResponse{
+    public function index():JsonResponse{
         $locales = Locale::orderBy("name")->get(['id', 'code', 'name']);
         return response()->json($locales);
+    }
+
+    /**
+     * Create a new Locale.
+     *
+     * Accepts a locale `code` and `name`.
+     *
+     * @authenticated
+     * @bodyParam code string required Unique locale code. Example: en, fr, es
+     * @bodyParam name string required Descriptive name for locale. Example: English
+     *
+     * @param \App\Http\Requests\SaveLocaleRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(SaveLocaleRequest $request): JsonResponse {
+        $locale = Locale::create($request->validated());
+        return response()->json($locale->only(['id', 'code', 'name']));
     }
 }

--- a/app/Http/Requests/SaveLocaleRequest.php
+++ b/app/Http/Requests/SaveLocaleRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Request;
+
+class SaveLocaleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            "code"=>["required","string",Rule::unique("locales","code")->ignore($this->route("content"))],
+            "name"=>["required","string"]
+        ];
+    }
+}

--- a/database/seeders/ContentSeeder.php
+++ b/database/seeders/ContentSeeder.php
@@ -24,9 +24,12 @@ class ContentSeeder extends Seeder
         $total_contents = 33_333;// ~33k
         $batch_size = 1000;
 
+        $command = $this->command;
+        $progress = $command->getOutput()->createProgressBar($total_contents/$batch_size);
+        $progress->start();
         LazyCollection::times($total_contents)
         ->chunk($batch_size)
-        ->each(function($chunk) use ($locales,$tags){
+        ->each(function($chunk) use ($locales,$tags,$progress){
             $contents = [];
             $now = now();
             $keyPrefixes = ['dashboard', 'auth', 'profile', 'settings', 'system', 'user'];
@@ -67,7 +70,9 @@ class ContentSeeder extends Seeder
 
             ContentTranslation::insert($content_translations);
             ContentTag::insert($content_tags);
-            echo "Inserted batch of " . count($chunk) . " contents with translations and tags" . PHP_EOL;
+            $progress->advance();
+            // echo "Inserted batch of " . count($chunk) . " contents with translations and tags" . PHP_EOL;
         });
+        $progress->finish();
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,7 +12,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        \App\Models\User::factory(count: 1)->create();
+        \App\Models\User::factory(count: 1)->create(["email"=>"test_user@tms.com"]);
 
         // \App\Models\User::factory()->create([
         //     'name' => 'Test User',

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,13 +23,18 @@ Route::middleware('auth:sanctum')->post('logout', [AuthController::class, 'logou
 
 Route::middleware('auth:sanctum')->group(function () {
 
-Route::get("locales",LocalesController::class);
-Route::get("tags",TagsController::class);
-Route::prefix("translations")->group(function(){
-    Route::get("export/{tag}/{locale?}",[TranslationsController::class,"export"]);
-    Route::get("/",[TranslationsController::class,"index"]);
-    Route::post("/",[TranslationsController::class,"create"]);
-    Route::put("/{content}",[TranslationsController::class,"update"]);
-});
+    Route::get("tags",TagsController::class);
+
+    Route::prefix("locales")->group(function(){
+        Route::get("/",[LocalesController::class,"index"]);
+        Route::post("/",[LocalesController::class,"store"]);
+    }); 
+
+    Route::prefix("translations")->group(function(){
+        Route::get("export/{tag}/{locale?}",[TranslationsController::class,"export"]);
+        Route::get("/",[TranslationsController::class,"index"]);
+        Route::post("/",[TranslationsController::class,"create"]);
+        Route::put("/{content}",[TranslationsController::class,"update"]);
+    });
 });
 

--- a/tests/Feature/LocalesControllerTest.php
+++ b/tests/Feature/LocalesControllerTest.php
@@ -13,16 +13,32 @@ class LocalesControllerTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
-    public function it_returns_all_locales()
-    {
+    protected function setUp(): void {
+        parent::setUp();
         $user = User::factory()->create();
         Sanctum::actingAs($user);
         $this->seed(LocaleSeeder::class);
+    }
 
+    /** @test */
+    public function it_returns_all_locales()
+    {
         $response = $this->getJson('/api/locales');
-
         $response->assertOk()
                  ->assertJsonStructure([['id', 'code', 'name']]);
     }
+
+    /** @test */
+    public function it_creates_a_locale(){
+        $payload = [
+            "name"=> "Urdu",
+            "code" => "ur"
+        ];
+
+        $response = $this->postJson("/api/locales",$payload);
+        $response->assertOk()->assertJsonStructure(["id","code","name"]);
+        $this->assertDatabaseHas("locales",["code"=>$payload["code"]]);
+        $this->assertDatabaseCount("locales",4);
+    }
+    
 }

--- a/tests/Feature/LocalesControllerTest.php
+++ b/tests/Feature/LocalesControllerTest.php
@@ -16,7 +16,7 @@ class LocalesControllerTest extends TestCase
     protected function setUp(): void {
         parent::setUp();
         $user = User::factory()->create();
-        Sanctum::actingAs($user);
+        Sanctum::actingAs($user,["*"]);
         $this->seed(LocaleSeeder::class);
     }
 


### PR DESCRIPTION
## Locale Management

-   Locales are stored in the `locales` table with `code` (e.g., `en`, `fr`, `es`) and `name` fields.
-   New locales can be added via the `/api/locales` POST route.
-   Each translation references a `locale_id` for efficient lookups.
-   This ensures the system can scale to new languages without schema changes.